### PR TITLE
Cambiada imagen de portada

### DIFF
--- a/secciones/00-tapa.md
+++ b/secciones/00-tapa.md
@@ -1,1 +1,1 @@
-![Tapa](/secciones/imagenes/SICP-traducido.png)
+![Tapa](/secciones/imagenes/SICP-traducido-reducido.png)


### PR DESCRIPTION
Ya que SICP-traducido.png no existe en el repositorio, usar SICP-traducido-reducido.png